### PR TITLE
python3 compatible next() for generator

### DIFF
--- a/api/openmatrix/File.py
+++ b/api/openmatrix/File.py
@@ -110,7 +110,9 @@ class File(tables.File):
 
         # Inspect the first CArray object to determine its shape
         if len(self) > 0:
-            self._shape = self.iter_nodes(self.root.data,'CArray').next().shape
+            # jwd: generator has no next funtion in python 3 
+            # next() function supported in both in python 2.6+ and python 3
+            self._shape = next(self.iter_nodes(self.root.data,'CArray')).shape
 
             # Store it if we can
             if self._iswritable():

--- a/api/setup.py
+++ b/api/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(
     name='OpenMatrix',
     keywords='openmatrix omx',
-    version='0.3.4',
+    version='0.3.4.1',
     author='Billy Charlton, Ben Stabler',
     author_email='billy@okbecause.com, benstabler@yahoo.com',
     packages=find_packages(),


### PR DESCRIPTION
replaced this
`            self._shape = self.iter_nodes(self.root.data,'CArray').next().shape
`
with this
```
            # jwd: generator has no next funtion in python 3 
            # next() function supported in both in python 2.6+ and python 3
            self._shape = next(self.iter_nodes(self.root.data,'CArray')).shape
```

Misspelled 'function' - sorry!