### PR TITLE
allow more generic array types in list_matrices

### DIFF
--- a/openmatrix/File.py
+++ b/openmatrix/File.py
@@ -136,7 +136,12 @@ class File(tables.File):
         matrices : list
             List of all matrix names stored in this OMX file.
         """
-        return [node.name for node in self.list_nodes(self.root.data,'CArray')]
+        matrices = []
+        if 'data' in self.root:
+            for node in self.list_nodes(self.root.data):
+                if isinstance(node, tables.Array) and len(node.shape) == 2:
+                    matrices.append(node.name)
+        return matrices
 
 
     def list_all_attributes(self):


### PR DESCRIPTION
Hi there,

To improve interoperability, this PR updates list_matrices() to detect any 2D tables.Array, not just the specific CArray type.

The OMX specification doesn't mandate a CArray, so this change brings the library into closer alignment with the spec and allows it to seamlessly read files created by a wider range of HDF5 tools, such as https://github.com/jamesmudd/jhdf .

Thanks for your consideration!